### PR TITLE
Switch required pydantic versioning to accomodate v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   'jsons==1.6.3',
   'tqdm==4.66.1',
   "pyluwen @ git+https://github.com/tenstorrent/luwen.git@v0.3.8#subdirectory=crates/pyluwen",
+  'pydantic>=1.2',
 ]
 
 optional-dependencies.dev = [

--- a/tt_tools_common/reset_common/host_reset_log.py
+++ b/tt_tools_common/reset_common/host_reset_log.py
@@ -11,8 +11,16 @@ import base64
 import inspect
 import datetime
 from pathlib import Path
-from pydantic import BaseModel
-from pydantic.fields import Field
+try:
+    # Try the newer v2 pydantic and use that first
+    from pydantic.v1 import BaseModel
+    from pydantic.v1.fields import Field
+except:
+    # Assume we are on v1 and give that a go
+    from pydantic import BaseModel
+    from pydantic.fields import Field
+
+
 from typing import Any, Union, List, TypeVar, Generic
 
 


### PR DESCRIPTION
Pydantic has a ground up re-write that's starting to make it into newer distros, F40, OpenSuse Tumbleweed, etc which includes pydantic v1 support, but breaks the default importing we are doing.

This adjusts the base pydantic in pyproject.toml to be a minimum of 1.2 (to meet Ubuntu 20.04 baseline requirements) and adds a try/except block to try loading the correct pydantic version where we are expecting.

Quick check on F40, in a venv, this plus the change in tt-tools-common to do roughly the same thing should sort out tenstorrent/tt-smi#27