### PR TITLE
Remove nr_hugepages from HostCompatibilityInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.4.13 - 23/1/2025
+
+- Removed nr\_hugepages count from compatibility, as hugepages allocation is tricky
+  and deserves its own widget elsewhere.
+
 ## 1.4.12 - 16/1/2025
-### Changed
 
 - Added TTHostCompatibilityMenu to replace Host Info and Compatibility boxes
 - Added a count of nr\_hugepages to the TTHostCompatibilityMenu

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tt-tools-common"
-version = "1.4.12"
+version = "1.4.13"
 description = "Common library for Tenstorrent tooling"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/tt_tools_common/utils_common/system_utils.py
+++ b/tt_tools_common/utils_common/system_utils.py
@@ -103,13 +103,6 @@ def get_host_info() -> dict:
         "Driver": "TT-KMD " + get_driver_version(),
     }
 
-
-def get_nr_hugepages() -> str:
-    with open("/proc/sys/vm/nr_hugepages", "r") as f:
-        nr = f.read().rstrip()
-    return nr
-
-
 def get_host_compatibility_info() -> Dict[str, Union[str, Tuple]]:
     """
     Return host info with system compatibility notes
@@ -145,12 +138,6 @@ def get_host_compatibility_info() -> Dict[str, Union[str, Tuple]]:
         checklist["Memory"] = host_info["Memory"]
     else:
         checklist["Memory"] = (host_info["Memory"], "32GB+")
-
-    nr_hugepages = get_nr_hugepages()
-    if int(nr_hugepages) < 1:
-        checklist["Hugepages"] = (nr_hugepages, "See Quickstart docs")
-    else:
-        checklist["Hugepages"] = nr_hugepages
 
     if host_info["Driver"]:
         checklist["Driver"] = host_info["Driver"]


### PR DESCRIPTION
This is much more complicated than I originally assumed, and the count we pull from isn't updated by the standard hugepages allocation strategy. Rather than trying to simplify this to one line, I'm opting instead to remove it until we can build hugepages their own widget.