### PR TITLE
Improve consistency and typing in reset_common parser behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.4.15 - 05/05/2025
+
+### Changed
+- parse\_reset\_json now returns a ResetInput with stricter typing
+
 ## 1.4.14 - 04/02/2025
 
 ### Added
-- New flags in reset config file generation to disable sw_version reporting
+- New flags in reset config file generation to disable sw\_version reporting
 
 ## 1.4.13 - 23/1/2025
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tt-tools-common"
-version = "1.4.14"
+version = "1.4.15"
 description = "Common library for Tenstorrent tooling"
 readme = "README.md"
 requires-python = ">=3.7"


### PR DESCRIPTION
Add ResetType and ResetInput types
These new types help reduce UB and provide strict type checking across
tools which need to use the reset parser. The parser should now be
invoked in all cases in tools which use it, and returns a ResetInput
with one of three ResetTypes:

- ALL (None value)
- CONFIG_JSON (dict value, parsed from JSON file)
- ID_LIST (List[int] value, provided by user via CLI)

In tt-smi, these types can now inform behavior while making what has
actually been provided more clear. In tt-topology, we can now perform
type checking on the input and only act if we get a CONFIG_JSON
ResetInput.
