### PR TITLE
Make reset logic for Blackhole more resilient

### DIFF
--- a/tt_tools_common/reset_common/bh_reset.py
+++ b/tt_tools_common/reset_common/bh_reset.py
@@ -31,15 +31,25 @@ class BHChipReset:
     TENSTORRENT_RESET_DEVICE_CONFIG_WRITE = 2
     A3_STATE_PROP_TIME = 0.03
     POST_RESET_MSG_WAIT_TIME = 2
+    POST_RESET_DEV_WAIT_TIME = 0.1
+    RESET_RETRY_DELAY = 0.00001
     MSG_TRIGGER_SPI_COPY_LtoR = 0x50
     MSG_TYPE_ARC_STATE3 = 0xA3
     MSG_TYPE_TRIGGER_RESET = 0x56
 
     def reset_device_ioctl(self, interface_id: int, flags: int) -> bool:
         dev_path = f"/dev/tenstorrent/{interface_id}"
-        dev_fd = os.open(
-            dev_path, os.O_RDWR | os.O_CLOEXEC
-        )  # Raises FileNotFoundError and other appropriate exceptions.
+        elapsed = 0
+        start_time = time.time()
+        while elapsed < self.POST_RESET_DEV_WAIT_TIME:
+            try:
+                dev_fd = os.open(
+                    dev_path, os.O_RDWR | os.O_CLOEXEC
+                )  # Raises FileNotFoundError and other appropriate exceptions.
+                break
+            except FileNotFoundError:
+                elapsed = time.time() - start_time
+                time.sleep(self.RESET_RETRY_DELAY)
         try:
             reset_device_in_struct = "II"
             reset_device_out_struct = "II"
@@ -92,19 +102,29 @@ class BHChipReset:
         post_reset_wait = self.POST_RESET_MSG_WAIT_TIME
 
         # Collect device bdf and trigger resets for all BH chips in order
-        for pci_interface in pci_interfaces:
-            # TODO: Make this check fallible
-            chip = PciChip(pci_interface=pci_interface)
-            pci_bdf = chip.get_pci_bdf()
-            pci_bdf_list[pci_interface] = pci_bdf
-            if reset_m3:
-                # A full bmfw upgrade can take awhile
-                post_reset_wait = 60
-                chip.arc_msg(self.MSG_TYPE_TRIGGER_RESET, wait_for_done=False, arg0=3)
-            else:
-                self.reset_device_ioctl(
-                    pci_interface, self.TENSTORRENT_RESET_DEVICE_CONFIG_WRITE
-                )
+        # it might take a few seconds before kernel module picks up a device
+        elapsed = 0
+        start_time = time.time()
+        while elapsed < post_reset_wait:
+            try:
+                for pci_interface in pci_interfaces:
+                    # TODO: Make this check fallible
+                    chip = PciChip(pci_interface=pci_interface)
+                    pci_bdf = chip.get_pci_bdf()
+                    pci_bdf_list[pci_interface] = pci_bdf
+                    if reset_m3:
+                        # A full bmfw upgrade can take awhile
+                        post_reset_wait = 60
+                        chip.arc_msg(self.MSG_TYPE_TRIGGER_RESET, wait_for_done=False, arg0=3)
+                    else:
+                        self.reset_device_ioctl(
+                            pci_interface, self.TENSTORRENT_RESET_DEVICE_CONFIG_WRITE
+                        )
+                break
+            except FileNotFoundError:
+                time.sleep(0.0001)
+                elapsed = time.time() - start_time
+                continue
 
         # check command.memory in config space to see if reset bit is set
         # 0 means config space reset happened correctly
@@ -113,9 +133,8 @@ class BHChipReset:
         completed = 0
         failures = 0
         files_map = {
-            pci_interface: open(
-                f"/sys/bus/pci/devices/{pci_bdf_list[pci_interface]}/config", "rb"
-            )
+            pci_interface:
+                f"/sys/bus/pci/devices/{pci_bdf_list[pci_interface]}/config"
             for pci_interface in pci_interfaces
         }
 
@@ -132,15 +151,21 @@ class BHChipReset:
             f"Waiting for up to {post_reset_wait} seconds for asic to come back after reset"
         )
         while elapsed < post_reset_wait:
-            for pci_interface, file in files_map.items():
-                command_memory_byte = os.pread(file.fileno(), 1, 4)
-                reset_bit = (
-                    int.from_bytes(command_memory_byte, byteorder="little") >> 1
-                ) & 1
-                # Overwrite to store the last value
-                reset_complete_bit_map[pci_interface] = (
-                    True if reset_bit == 0 else False
-                )
+            try:
+                for pci_interface, filename in files_map.items():
+                    with open(filename, 'rb') as file:
+                        command_memory_byte = os.pread(file.fileno(), 1, 4)
+                        reset_bit = (
+                            int.from_bytes(command_memory_byte, byteorder="little") >> 1
+                        ) & 1
+                        # Overwrite to store the last value
+                        reset_complete_bit_map[pci_interface] = (
+                            True if reset_bit == 0 else False
+                        )
+            except FileNotFoundError:
+                time.sleep(self.RESET_RETRY_DELAY)
+                elapsed = time.time() - start_time
+                continue
 
             # During bmfw upgrade it may take awhile for the asic to go down after sending the message.
             # So to be safe only early exit if we know the asic has actually gone into reset
@@ -151,7 +176,7 @@ class BHChipReset:
                 if can_early_exit:
                     break
 
-            time.sleep(0.001)
+            time.sleep(self.RESET_RETRY_DELAY)
             elapsed = time.time() - start_time
 
         # Check the last value of all the reset bits and report if any of them are not 0


### PR DESCRIPTION
 * On my machine, current delay is too long and it won't be able to read the reset state all the time, reducing delay between attempts by 10x
 * During reset, old device will disappear for a while, adding retry logic there and handle FileNotFound error.
 * During reset, once the driver reloads all sysfs entries will be recreated, so previously opened filehandles will become invalid, therefore script either need to open files inside the loop (less invasive change, implemented here), or handle OSError exception and reopen the file (but if the driver is reloading, that would fail as well and require extra logic around exception handling)