### PR TITLE
chore: loosen dependency requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,20 +24,20 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
-  'distro==1.8.0',
-  'elasticsearch==8.11.0',
-  'psutil==5.9.6',
-  'pyyaml==6.0.1',
-  'rich==13.7.0',
-  'textual==0.59.0',
-  'requests==2.32.3',
-  'tqdm==4.66.3',
+  'distro>=1.8.0',
+  'elasticsearch>=8.11.0',
+  'psutil>=5.9.6',
+  'pyyaml>=6.0.1',
+  'rich>=13.7.0',
+  'textual>=0.59.0',
+  'requests>=2.32.3',
+  'tqdm>=4.66.3',
   'pydantic>=1.2',
 ]
 
 optional-dependencies.dev = [
-  'black==23.11.0',
-  'pre-commit==3.5.0',
+  'black>=23.11.0',
+  'pre-commit>=3.5.0',
   "pyluwen @ git+https://github.com/tenstorrent/luwen.git@v0.4.9#subdirectory=crates/pyluwen",
 ]
 


### PR DESCRIPTION
Loosen dependency requirements for tt-tools-common. By avoiding fixing dependencies to a specific version we can minimize conflicts with other packages. We can always restrict packages to a specific version range if we run into issues.