### PR TITLE
Add NixOS to distro check, fix driver check

### DIFF
--- a/tt_tools_common/utils_common/system_utils.py
+++ b/tt_tools_common/utils_common/system_utils.py
@@ -153,6 +153,12 @@ def get_host_info() -> dict:
     kernel: str = uname.release
     hostname: str = uname.node
 
+    driver_version = get_driver_version()
+    if driver_version == None:
+        driver = None
+    else:
+        driver = "TT-KMD " + driver_version,
+
     return {
         "OS": os,
         "Distro": distro_name,
@@ -161,7 +167,7 @@ def get_host_info() -> dict:
         "Platform": uname.machine,
         "Python": platform.python_version(),
         "Memory": get_size(svmem.total),
-        "Driver": "TT-KMD " + get_driver_version(),
+        "Driver": driver,
     }
 
 def get_host_compatibility_info() -> Dict[str, Union[str, Tuple]]:
@@ -188,8 +194,14 @@ def get_host_compatibility_info() -> Dict[str, Union[str, Tuple]]:
             checklist["Distro"] = host_info["Distro"]
         else:
             checklist["Distro"] = (host_info["Distro"], "20.04 or 22.04")
+    elif distro.id() == "nixos":
+        distro_version = float(".".join(distro.version_parts()[:2]))
+        if distro_version >= 25.05:
+            checklist["Distro"] = host_info["Distro"]
+        else:
+            checklist["Distro"] = (host_info["Distro"], "25.05 or 25.11")
     else:
-        checklist["Distro"] = (host_info["Distro"], "Ubuntu 20.04 or 22.04")
+        checklist["Distro"] = (host_info["Distro"], "Ubuntu 20.04 or 22.04, NixOS 25.05 or 25.11")
 
     checklist["Kernel"] = host_info["Kernel"]
     checklist["Hostname"] = host_info["Hostname"]


### PR DESCRIPTION
This PR solves two problems:
1. I get compatibility warnings when I run NixOS, I am providing support so this isn't a problem.
2. If the `get_host_info` function is called without calling `check_driver_version` first, an error appears for concatenating a string and none together.
```
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    tt_tools_common.utils_common.system_utils.get_host_compatibility_info()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/ross/tt-tools-common/tt_tools_common/utils_common/system_utils.py", line 176, in get_host_compatibility_info
    host_info = get_host_info()
  File "/home/ross/tt-tools-common/tt_tools_common/utils_common/system_utils.py", line 164, in get_host_info
    "Driver": "TT-KMD " + get_driver_version(),
              ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
TypeError: can only concatenate str (not "NoneType") to str
```

So for example, on my MBP I get this:
```
{'OS': 'Linux (aarch64)', 'Distro': 'NixOS 25.11 (Xantusia)', 'Kernel': '6.14.8-asahi', 'Hostname': 'hizack-b', 'Python': '3.13.4', 'Memory': ('15.07 GB', '32GB+'), 'Driver': (None, 'TT-KMD v1.27+')}
```