### PR TITLE
Add support for new reset implementation

### DIFF
--- a/tt_tools_common/reset_common/bh_reset.py
+++ b/tt_tools_common/reset_common/bh_reset.py
@@ -13,11 +13,12 @@ import struct
 from typing import List
 from pyluwen import PciChip
 from tt_tools_common.ui_common.themes import CMD_LINE_COLOR
-from tt_tools_common.utils_common.tools_utils import read_refclk_counter
 from tt_tools_common.utils_common.system_utils import (
-    # check_driver_version,
     get_host_info,
+    is_driver_version_at_least,
+    get_driver_version
 )
+from tt_tools_common.reset_common.chip_reset import ChipReset
 
 
 class BHChipReset:
@@ -65,6 +66,18 @@ class BHChipReset:
         self, pci_interfaces: List[int], reset_m3: bool = False, silent: bool = False
     ) -> List[PciChip]:
         """Performs a full LDS reset of a list of chips"""
+        
+        # Use new reset for driver version >= 2.4.0
+        if is_driver_version_at_least(get_driver_version(), "2.4.0"):
+            return ChipReset().full_lds_reset(pci_interfaces, reset_m3, silent)
+
+        if not silent:
+            print(
+                CMD_LINE_COLOR.YELLOW,
+                "Notice: Using legacy BH reset implementation. This will be removed in a later version.",
+                "Please upgrade tt-kmd to version 2.4.0 or newer to use the updated reset sequence.",
+                CMD_LINE_COLOR.ENDC,
+            )
 
         # TODO: FOR BH Check the driver version and bail if link reset cannot be supported
         # check_driver_version(operation="board reset")

--- a/tt_tools_common/reset_common/chip_reset.py
+++ b/tt_tools_common/reset_common/chip_reset.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+This file contains functions used to do a PCIe level reset for Blackhole or Wormhole chip.
+"""
+
+import os
+import sys
+import time
+import fcntl
+import struct
+import glob
+from enum import IntEnum
+from typing import List
+from pyluwen import PciChip
+from tt_tools_common.ui_common.themes import CMD_LINE_COLOR
+from tt_tools_common.utils_common.system_utils import (
+    check_driver_version,
+    get_host_info,
+)
+
+class IoctlResetFlags(IntEnum):
+    RESTORE_STATE = 0
+    RESET_PCIE_LINK = 1
+    CONFIG_WRITE = 2
+    USER_RESET = 3
+    ASIC_RESET = 4
+    ASIC_DMC_RESET = 5
+    POST_RESET = 6
+
+class ChipReset:
+    """Class to perform a chip-level reset on WH and BH PCIe boards"""
+
+    # magic numbers for reset
+    TENSTORRENT_IOCTL_MAGIC = 0xFA
+    TENSTORRENT_IOCTL_RESET_DEVICE = (TENSTORRENT_IOCTL_MAGIC << 8) | 6
+
+    def reset_device_ioctl(self, interface_id: int, flags: int) -> bool:
+        dev_path = f"/dev/tenstorrent/{interface_id}"
+        dev_fd = os.open(
+            dev_path, os.O_RDWR | os.O_CLOEXEC
+        )  # Raises FileNotFoundError and other appropriate exceptions.
+        try:
+            reset_device_in_struct = "II"
+            reset_device_out_struct = "II"
+            reset_device_struct = reset_device_in_struct + reset_device_out_struct
+
+            input_size_bytes = struct.calcsize(reset_device_in_struct)
+            output_size_bytes = struct.calcsize(reset_device_out_struct)
+
+            reset_device_buf = bytearray(
+                struct.pack(reset_device_struct, output_size_bytes, flags, 0, 0)
+            )
+            fcntl.ioctl(
+                dev_fd, self.TENSTORRENT_IOCTL_RESET_DEVICE, reset_device_buf
+            )  # Raises OSError
+
+            output_buf = reset_device_buf[input_size_bytes:]
+            _, result = struct.unpack(reset_device_out_struct, output_buf)
+
+            return result == 0
+        finally:
+            os.close(dev_fd)
+
+    def wait_for_device_to_reappear(self, bdf: str, timeout: int = 10) -> int:
+        print(
+            CMD_LINE_COLOR.BLUE,
+            f"Waiting for devices to reappear on pci bus...",
+            CMD_LINE_COLOR.ENDC,)
+        deadline = time.time() + timeout
+        device_reappeared = False
+
+        while time.time() < deadline and not device_reappeared:
+            matches = glob.glob(f"/sys/bus/pci/devices/{bdf}/tenstorrent/tenstorrent!*")
+            if matches:
+                interface_id = int(os.path.basename(matches[0]).replace("tenstorrent!", ""))
+                dev_path = f"/dev/tenstorrent/{interface_id}"
+                if os.path.exists(dev_path):
+                    device_reappeared = True
+
+        if not device_reappeared:
+            print(
+                CMD_LINE_COLOR.RED,
+                f"Timeout waiting for device at PCI index {interface_id} to reappear.",
+                CMD_LINE_COLOR.ENDC,
+            )
+            sys.exit(1)
+
+        return interface_id
+
+
+    def full_lds_reset(
+        self, pci_interfaces: List[int], reset_m3: bool = False, silent: bool = False
+    ) -> List[PciChip]:
+        """Performs a full LDS reset of a list of chips"""
+
+        # Check the driver version and bail if reset cannot be supported
+        check_driver_version(operation="reset", minimum_required_version_str="2.4.0")
+
+        # Due to how Arm systems deal with PCIe device rescans, WH device resets don't work on that platform.
+        # Check for platform and bail if it's Arm
+        platform = get_host_info()["Platform"]
+        if platform.startswith("arm") or platform.startswith("aarch"):
+            print(
+                CMD_LINE_COLOR.RED,
+                "Cannot perform board reset on Arm systems, please reboot the system to reset the boards. Exiting...",
+                CMD_LINE_COLOR.ENDC,
+            )
+            sys.exit(1)
+
+        # Remove duplicates from the input list of PCI interfaces
+        pci_interfaces = list(set(pci_interfaces))
+        if not silent:
+            print(
+                f"{CMD_LINE_COLOR.BLUE} Starting reset on BH devices at PCI indices: {str(pci_interfaces)[1:-1]} {CMD_LINE_COLOR.ENDC}"
+            )
+
+        bdf_list = []
+
+        for pci_interface in pci_interfaces:
+            chip = PciChip(pci_interface=pci_interface)
+            bdf = chip.get_pci_bdf()
+            bdf_list.append(bdf)
+            
+            if reset_m3:
+                reset_flag = IoctlResetFlags.ASIC_DMC_RESET
+            else:
+                reset_flag = IoctlResetFlags.ASIC_RESET
+
+            self.reset_device_ioctl(pci_interface, reset_flag)
+
+        post_reset_wait = 20 if reset_m3 else max(2, 0.4 * len(pci_interfaces))
+        print(
+            CMD_LINE_COLOR.BLUE,
+            f"Waiting for {post_reset_wait} seconds for potential hotplug removal.",
+            CMD_LINE_COLOR.ENDC
+        )
+        time.sleep(post_reset_wait)
+
+        for pci_interface,bdf in zip(pci_interfaces,bdf_list):
+            new_id = self.wait_for_device_to_reappear(bdf) 
+
+            if self.reset_device_ioctl(new_id, IoctlResetFlags.POST_RESET):
+                print(
+                    f"{CMD_LINE_COLOR.GREEN} Reset successfully completed for device at PCI index {pci_interface}. {CMD_LINE_COLOR.ENDC}"
+                )
+            else:
+                print(
+                    f"{CMD_LINE_COLOR.RED} Post-reset actions did not complete successfully for device at PCI index {pci_interface}. {CMD_LINE_COLOR.ENDC}"
+                )
+                sys.exit(1)
+        
+        # All went well print success message
+        # other sanity checks go here
+        if not silent:
+            print(
+                f"{CMD_LINE_COLOR.BLUE} Finishing reset on BH devices at PCI indices: {str(pci_interfaces)[1:-1]} {CMD_LINE_COLOR.ENDC}"
+            )
+
+        pci_chips = [PciChip(pci_interface=interface) for interface in pci_interfaces]
+        return pci_chips

--- a/tt_tools_common/reset_common/wh_reset.py
+++ b/tt_tools_common/reset_common/wh_reset.py
@@ -17,7 +17,10 @@ from tt_tools_common.utils_common.tools_utils import read_refclk_counter
 from tt_tools_common.utils_common.system_utils import (
     check_driver_version,
     get_host_info,
+    is_driver_version_at_least,
+    get_driver_version
 )
+from tt_tools_common.reset_common.chip_reset import ChipReset
 
 
 class WHChipReset:
@@ -64,6 +67,18 @@ class WHChipReset:
         self, pci_interfaces: List[int], reset_m3: bool = False, silent: bool = False
     ) -> List[PciChip]:
         """Performs a full LDS reset of a list of chips"""
+        
+        # Use new reset for driver version >= 2.4.0
+        if is_driver_version_at_least(get_driver_version(), "2.4.0"):
+            return ChipReset().full_lds_reset(pci_interfaces, reset_m3, silent)
+
+        if not silent:
+            print(
+                CMD_LINE_COLOR.YELLOW,
+                "Notice: Using legacy WH reset implementation. This will be removed in a later version.",
+                "Please upgrade tt-kmd to version 2.4.0 or newer to use the updated reset sequence.",
+                CMD_LINE_COLOR.ENDC
+            )
 
         # Check the driver version and bail if link reset cannot be supported
         check_driver_version(operation="board reset")


### PR DESCRIPTION
Add support for the new reset implementation in ChipReset using @nxuTT's t6py implementation as a reference. The driver is now responsible for issuing the reset message and checking the reset marker bit. Keep support for legacy BHChipReset and WHChipReset for now. In the full_lds_reset methods in those classes, check the driver version and perform the new reset if supported.

A post-reset wait for hotplug removal has been added (scales by number of pci devices) and the timeout per-device for waiting for the device to reappear on the pci bus has been increased to 10s. Do we want to keep this timing?

This PR assumes that the next tt-kmd version will be 2.4.0 and the new reset mechanism will become available with that version, will change accordingly if not.