### PR TITLE
ChipReset: Perform SBR first, then chip reset

### DIFF
--- a/tt_tools_common/reset_common/bh_reset.py
+++ b/tt_tools_common/reset_common/bh_reset.py
@@ -67,15 +67,15 @@ class BHChipReset:
     ) -> List[PciChip]:
         """Performs a full LDS reset of a list of chips"""
         
-        # Use new reset for driver version >= 2.4.0
-        if is_driver_version_at_least(get_driver_version(), "2.4.0"):
+        # Use new reset for driver version >= 2.4.1
+        if is_driver_version_at_least(get_driver_version(), "2.4.1"):
             return ChipReset().full_lds_reset(pci_interfaces, reset_m3, silent)
 
         if not silent:
             print(
                 CMD_LINE_COLOR.YELLOW,
                 "Notice: Using legacy BH reset implementation. This will be removed in a later version.",
-                "Please upgrade tt-kmd to version 2.4.0 or newer to use the updated reset sequence.",
+                "Please upgrade tt-kmd to version 2.4.1 or newer to use the updated reset sequence.",
                 CMD_LINE_COLOR.ENDC,
             )
 

--- a/tt_tools_common/reset_common/chip_reset.py
+++ b/tt_tools_common/reset_common/chip_reset.py
@@ -96,7 +96,7 @@ class ChipReset:
         """Performs a full LDS reset of a list of chips"""
 
         # Check the driver version and bail if reset cannot be supported
-        check_driver_version(operation="reset", minimum_required_version_str="2.4.0")
+        check_driver_version(operation="reset", minimum_required_version_str="2.4.1")
 
         # Due to how Arm systems deal with PCIe device rescans, WH device resets don't work on that platform.
         # Check for platform and bail if it's Arm
@@ -122,7 +122,17 @@ class ChipReset:
             chip = PciChip(pci_interface=pci_interface)
             bdf = chip.get_pci_bdf()
             bdf_list.append(bdf)
-            
+        
+        for pci_interface in pci_interfaces:
+            if not self.reset_device_ioctl(pci_interface, IoctlResetFlags.RESET_PCIE_LINK):
+                print(
+                    CMD_LINE_COLOR.YELLOW,
+                    f"Warning: Secondary bus reset not completed for device at PCI index {pci_interface}. Continuing with reset.",
+                    CMD_LINE_COLOR.ENDC
+                )
+
+
+        for pci_interface in pci_interfaces:
             if reset_m3:
                 reset_flag = IoctlResetFlags.ASIC_DMC_RESET
             else:

--- a/tt_tools_common/reset_common/wh_reset.py
+++ b/tt_tools_common/reset_common/wh_reset.py
@@ -68,15 +68,15 @@ class WHChipReset:
     ) -> List[PciChip]:
         """Performs a full LDS reset of a list of chips"""
         
-        # Use new reset for driver version >= 2.4.0
-        if is_driver_version_at_least(get_driver_version(), "2.4.0"):
+        # Use new reset for driver version >= 2.4.1
+        if is_driver_version_at_least(get_driver_version(), "2.4.1"):
             return ChipReset().full_lds_reset(pci_interfaces, reset_m3, silent)
 
         if not silent:
             print(
                 CMD_LINE_COLOR.YELLOW,
                 "Notice: Using legacy WH reset implementation. This will be removed in a later version.",
-                "Please upgrade tt-kmd to version 2.4.0 or newer to use the updated reset sequence.",
+                "Please upgrade tt-kmd to version 2.4.1 or newer to use the updated reset sequence.",
                 CMD_LINE_COLOR.ENDC
             )
 


### PR DESCRIPTION
In tt-kmd 2.4.1, secondary bus reset was removed from the ASIC reset code path, so now it must be performed before reset for each device on the tools side.

This is to make the time between each chip's reset as small as possible to reduce ethernet timing issues.

Also, create the bdf list before issuing ioctl resets.

Context for this change in tt-kmd: https://github.com/tenstorrent/tt-kmd/pull/134