### PR TITLE
Fix update_data when row count decreases

### DIFF
--- a/tt_tools_common/ui_common/widgets.py
+++ b/tt_tools_common/ui_common/widgets.py
@@ -100,17 +100,16 @@ class TTDataTable(ScrollableContainer):
         #     [len(x)
         #      for x in rows]), "Data doesn't have expected num of columns"
 
+        if self.dt.row_count != len(rows):
+            self.dt.clear()
+            self.dt.add_rows(rows)
+            return
+
         for i, row in enumerate(rows):
             for j, val in enumerate(row):
-                try:
-                    # update cell values one by one
-                    self.dt.update_cell_at(
-                        coordinate=Coordinate(column=j, row=i), value=val
-                    )
-                except CellDoesNotExist:
-                    # there are more rows than there used to be
-                    self.dt.clear()
-                    self.dt.add_rows(rows)
+                self.dt.update_cell_at(
+                    coordinate=Coordinate(column=j, row=i), value=val
+                )
 
     def compose(self) -> ComposeResult:
         container = ScrollableContainer(self.dt, id=self.id)


### PR DESCRIPTION
Old code caught CellDoesNotExist to handle new rows, but did nothing when rows were removed.

Behavior:
 1. Check row count first
 2. If changed, clear and re-add
 3. If same, update cells directly